### PR TITLE
Permit empty collection of vars in example file

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ const isWindows = () => {
     return isWsl || process.platform === 'win32';
 };
 
-// eslint-disable-next-line max-statements
 const envy = (input) => {
     const envPath = input || '.env';
     const examplePath = envPath + '.example';
@@ -69,9 +68,6 @@ const envy = (input) => {
     const exampleEnvKeys = Object.keys(exampleEnv);
     const camelizedExampleEnvKeys = Object.keys(camelcaseKeys(exampleEnv));
 
-    if (exampleEnvKeys.length === 0) {
-        throw new Error(`At least one entry is required in ${examplePath}`);
-    }
     const exampleHasValues = Object.values(exampleEnv).some((val) => {
         return val !== '';
     });

--- a/test.js
+++ b/test.js
@@ -39,6 +39,10 @@ test('returns excess vars in .env', (t) => {
     });
 });
 
+test('returns empty collection of vars', (t) => {
+    t.deepEqual(fixture('empty-example'), {});
+});
+
 test('can parse complex values', (t) => {
     // Complex values are those which have a high risk of confusing the parser,
     // such as those using reserved characters.
@@ -96,14 +100,6 @@ test('requires secure file permissions on .env.example', (t) => {
     }, Error);
     const filepath = path.join('fixture', 'unsafe-perm-example-602', '.env.example');
     t.is(err.message, `File must not be writable by others. Fix: chmod o-w '${filepath}'`);
-});
-
-test('requires at least one entry in .env.example', (t) => {
-    const err = t.throws(() => {
-        fixture('empty-example');
-    }, Error);
-    const filepath = path.join('fixture', 'empty-example', '.env.example');
-    t.is(err.message, `At least one entry is required in ${filepath}`);
 });
 
 test('does not modify process.env', (t) => {


### PR DESCRIPTION
In https://github.com/hapipal/boilerplate/issues/91#issuecomment-677774990 it was mentioned that the hapipal boilerplate's use-case for having empty `.env` and `.env.example` files seemed reasonable and that a PR would be welcome.  This is that PR ☺️ 

To document the use-case: the boilerplate supports a single, optional `PORT` environment variable with a default set via runtime validation.  It's desired to not force the user to fill this environment variable in manually during installation.  The standard way to handle optional variables with envy is to just leave them commented-out in `.env.example`, but in our case that would result in an empty example file, which envy does not allow.  This PR removes the check for an empty example file, which is a breaking change.