### PR TITLE
Support options: explicit opts.env and opts.allowUnknown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 
 node_js:
+  - 14
+  - 12
   - 10
-  - 8
 
 os:
   - linux
   - osx
+  - windows

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright © 2017 Seth Holladay <me@seth-holladay.com> (https://seth-holladay.com)
+Copyright © 2020 Project contributors
+Copyright © 2017-2020 Seth Holladay <me@seth-holladay.com> (https://seth-holladay.com)
 
 Mozilla Public License, version 2.0
 
@@ -362,4 +363,3 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       This Source Code Form is "Incompatible
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
-


### PR DESCRIPTION
While working on #7 and testing things out against the hapipal boilerplate, I had some thought which I figured I'd express through code, which is what you find here.  There are a few different ideas in here, which are fully tested but not documented.  If you want to accept any of these ideas, I'd be happy to complete the documentation and split-out any features you do want from those you do not.

 - Drop node v8 support
Node v8 has hit its end-of-life.  I know you're planning a new major release for #7, so thought it might be a good opportunity to end support for old versions of node.

 - Test against windows
It's clear this library is intended to work with windows, so I figured we might as well give it "the treatment" and ensure the test suite also runs properly everywhere.  _This may require a bit more work, and I'm willing to spend some more time with it._

 - Fix all lint warnings
I spent some time cleaning-up lint warnings and `// eslint-disable-line`s while I was in there simply because it wasn't too hard to do so.  Admittedly the 30 statement limit within functions made me write some things differently than I would have liked, but it still seems like a good result.

 - Support `env` option to override implicit `process.env` input
Supporting an option to allow the user to pass the `env` input allows a few nice things: a. the user can pre-process the environment with some of their own logic if they like without mutating `process.env`, b. by making envy a little more pure it makes some cases simpler to test, which I was able to leverage immediately (including writing the first test of some behavior that predates this PR: "ignores unknown global env vars by default").

 - Support `allowUnknown` option to allow specific vars not listed in `.env` files
While working with the boilerplate I ran into some more use-cases that seemed to call for this.  For example, I would like to always support `NODE_ENV` without forcing the user to manually provide it in the example file and `.env` file.  Silently ignoring `NODE_ENV=production` (e.g. if the users passes it via CLI or a process runner) could cause issues for users when that environment variable turns on/off important checks, routines, and configurations in production.  And at the same time I would like this var to remain optional, as `production` is the only special value that the boilerplate cares about (in the 12 factor spirit, we minimize use of "named groups").  It's worth noting that the `.env` file is also not used in some variants of the boilerplate, e.g. the [docker flavor](https://github.com/hapipal/boilerplate#docker).  I think this is a reasonable escape hatch for users with special needs for their application, but I also see how it may not be a welcome feature.  I would propose envy maintain the same default functionality, because I do like envy's opinionation on this point even though it causes issues for the boilerplate.